### PR TITLE
feat: rewrite get pass for details bar

### DIFF
--- a/ajax/ajax.php
+++ b/ajax/ajax.php
@@ -13,7 +13,14 @@ $database = new DataBase();
 
 // Get password data by ID for the overview page
 if (isset($_GET['getPass'])) {
-    echo json_encode($database->get_password($_GET['getPass']));
+    $password = $database->get_password($_GET['getPass']);
+
+    if ($password === null) {
+        // Send http code 204 = No content
+        http_response_code('204');
+    }
+
+    echo json_encode($password);
 }
 
 // Generate a password with specified length, and optional digits and special characters

--- a/ajax/ajax.php
+++ b/ajax/ajax.php
@@ -13,7 +13,7 @@ $database = new DataBase();
 
 // Get password data by ID for the overview page
 if (isset($_GET['getPass'])) {
-    echo json_encode($database->get_all_entries($database->getUserId(), $_GET['mode'])[$_GET['getPass']]);
+    echo json_encode($database->get_password($_GET['getPass']));
 }
 
 // Generate a password with specified length, and optional digits and special characters

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,8 @@
         "ircmaxell/random-lib": "^1.2",
         "bjeavons/zxcvbn-php": "^1.3",
         "catfan/medoo": "^2.1",
-        "kelvinmo/fernet-php": "^1.0"
+        "kelvinmo/fernet-php": "^1.0",
+        "ext-json": "*"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0.0"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0bdd7027c36343d920ecad96b77648e5",
+    "content-hash": "ddb7a6ed83c9a0b1a7e77942d6e202e4",
     "packages": [
         {
             "name": "bjeavons/zxcvbn-php",
@@ -2122,7 +2122,9 @@
     "stability-flags": [],
     "prefer-stable": false,
     "prefer-lowest": false,
-    "platform": [],
+    "platform": {
+        "ext-json": "*"
+    },
     "platform-dev": [],
     "plugin-api-version": "2.3.0"
 }

--- a/css/overview.css
+++ b/css/overview.css
@@ -110,3 +110,8 @@ h1, h2, h3, h4, h5, h6 {
     color: #ff0000;
     font-weight: bold;
 }
+
+#details-error {
+    color: #ff0000;
+    font-weight: bold;
+}

--- a/db.php
+++ b/db.php
@@ -59,13 +59,17 @@ class DataBase {
             'id' => $entryId
         ]);
 
-        $result = $result[0];
+        if ($result !== []) {
+            $result = $result[0];
 
-        if ($result['password'] != '') {
-            $result['password'] = decrypt($result['password'], $_SESSION['masterpass']);
+            if ($result['password'] != '') {
+                $result['password'] = decrypt($result['password'], $_SESSION['masterpass']);
+            }
+
+            return $result;
         }
 
-        return $result;
+        return null;
     }
 
     // This method retrieves all websites for the specified user

--- a/db.php
+++ b/db.php
@@ -49,13 +49,23 @@ class DataBase {
     }
 
     // This method retrieves the encrypted password for the specified website
-    public function get_password($website) {
+    public function get_password($entryId) {
         $result = $this->database->select('passwords', [
-            'website'
+            'website',
+            'username',
+            'password',
+            'id'
         ], [
-            'website' => $website
+            'id' => $entryId
         ]);
-        return json_encode($result);
+
+        $result = $result[0];
+
+        if ($result['password'] != '') {
+            $result['password'] = decrypt($result['password'], $_SESSION['masterpass']);
+        }
+
+        return $result;
     }
 
     // This method retrieves all websites for the specified user

--- a/js/overview.js
+++ b/js/overview.js
@@ -29,23 +29,32 @@ $(document).ready(function() {
 
         // Fetch the password details from the server using AJAX
         fetch(ajaxUrl)
-        .then((response) => response.json())
-        .then((res) => {
-            // Display the retrieved password details in the appropriate elements
-            $('#details-website-link').text(res.website);
-            if (res.website.includes('http://') || res.website.includes('https://')) {
-                $("#details-website-link").prop("href", res.website);
-            } else {
-                $("#details-website-link").prop("href", 'http://' + res.website);
-            }
-            $('#details-username').text(res.username);
-            $('#details-password').text('*********');
-            $('input.entryId').val(res.id);
+            .then((response) => {
+                if (response.ok) {
+                    return response.json();
+                }
+                return Promise.reject()
+            })
+            .then((res) => {
+                // Display the retrieved password details in the appropriate elements
+                $('#details-website-link').text(res.website);
+                if (res.website.includes('http://') || res.website.includes('https://')) {
+                    $("#details-website-link").prop("href", res.website);
+                } else {
+                    $("#details-website-link").prop("href", 'http://' + res.website);
+                }
+                $('#details-username').text(res.username);
+                $('#details-password').text('*********');
+                $('input.entryId').val(res.id);
 
-            // Store the retrieved password in a variable to enable showing/hiding the password
-            showPass.password = res.password;
-            showPass.show = false;
-        })
+                // Store the retrieved password in a variable to enable showing/hiding the password
+                showPass.password = res.password;
+                showPass.show = false;
+            })
+            .catch(() => {
+                // TODO: error handling on the client sides maybe?
+                console.log('Not found');
+            });
     });
 
     // Function that handles click events on the "Clear" button

--- a/js/overview.js
+++ b/js/overview.js
@@ -5,9 +5,9 @@ $(document).ready(function() {
     let showPass = {'password': '', 'show': true};
 
     // When a password entry is clicked, fetch the password details and display them
-    $(".entries").click(function(event) {
+    $(".entries").click(function() {
         // Get the ID of the clicked entry
-        const id = event.currentTarget.id.replace('entry-', '');
+        const id = $(this).attr('data-id');
 
         // Show the password details and buttons
         $('#clear-details').show();
@@ -70,7 +70,7 @@ $(document).ready(function() {
         } else {
             $('#details-password').text('*********');
             showPass.show = false;
-        }    
+        }
 
     });
 

--- a/js/overview.js
+++ b/js/overview.js
@@ -52,8 +52,7 @@ $(document).ready(function() {
                 showPass.show = false;
             })
             .catch(() => {
-                // TODO: error handling on the client sides maybe?
-                console.log('Not found');
+                $('#details-error').text('Error during details gathering');
             });
     });
 
@@ -68,6 +67,7 @@ $(document).ready(function() {
         $('#details-edit').hide();
         $('#trash-form').hide();
         $('#favorite-form').hide();
+        $('#details-error').text('');
     });
 
     // Function that handles click events on the "Show Password" button

--- a/overview/index.php
+++ b/overview/index.php
@@ -142,6 +142,7 @@ switch ($_GET['mode']) {
                     <h3>Details</h3>
                     <button id="clear-details" style="display: none">X</button>
                 </section>
+                <p id="details-error"></p>
                 <h4>Website</h4>
                 <a href="" id="details-website-link"></a>
                 <h4>Username</h4>

--- a/overview/index.php
+++ b/overview/index.php
@@ -44,20 +44,20 @@ if (isset($_POST['id']) && $_POST['trash'] === 'trash') {
 if (isset($_POST['id']) && $_POST['favorite'] === 'favorite') {
     switch ($_GET['mode']) {
         case 'favorite':
-            // Call the moveEntryOutOfFavorite() method to remove the entry from 
+            // Call the moveEntryOutOfFavorite() method to remove the entry from
             // the user's favorites
             $database->moveEntryOutOfFavorite($_POST['id']);
             break;
 
         default:
-            // Call the moveEntryToFavorite() method to add the entry to 
+            // Call the moveEntryToFavorite() method to add the entry to
             // the user's favorites
             $database->moveEntryToFavorite($_POST['id']);
             break;
     }
 }
 
-// Call the deleteAfterThirtyDays() method to delete any entries that have been 
+// Call the deleteAfterThirtyDays() method to delete any entries that have been
 // in the trash for 30 days
 $database->deleteAfterThirtyDays();
 
@@ -109,7 +109,7 @@ switch ($_GET['mode']) {
 
                 <div class="overview-passwords-subheader">
                     <?php
-                    // If the user is currently in "trash" mode, display a message 
+                    // If the user is currently in "trash" mode, display a message
                     // about when entries will be deleted permanently
                     if ($_GET['mode'] === 'trash') {
                         echo '
@@ -128,7 +128,7 @@ switch ($_GET['mode']) {
                         <?php
                         // Loop through the list of entries and display them in a table
                         foreach ($entries as $key => $entry) {
-                            echo "<tr id='entry-{$key}' class='entries'>";
+                            echo "<tr class='entries' data-id='{$entry['id']}'>";
                             echo "<td>" . $entry['website'] . "</td>";
                             echo "<td>" . $entry['username'] . "</td>";
                             echo '</tr>';
@@ -155,7 +155,7 @@ switch ($_GET['mode']) {
                     <button type="submit" name="trash" value="trash">
                         <?php
                         // If the user is currently in "trash" mode, display a button to move
-                        // the entry out of the trash; otherwise, display a button to move 
+                        // the entry out of the trash; otherwise, display a button to move
                         // the entry to the trash
                         if ($_GET['mode'] === 'trash') {
                             echo 'Move out of trash';

--- a/tests/DbTest.php
+++ b/tests/DbTest.php
@@ -56,5 +56,25 @@ class DbTest extends TestCase {
         $result = $this->database->login('newusername', 'testpassword');
         $this->assertEquals("Success", $result);
     }
+
+    public function testGetPassword() {
+        $this->database->add_user('testuser', 'testpassword');
+        $this->database->login('testuser', 'testpassword');
+        $_SESSION['username'] = 'testuser';
+        $_SESSION['masterpass'] = 'testpassword';
+        $userid = $this->database->getUserId();
+        $this->database->add_password($userid, 'amazingsite', 'testusername', 'testpassword');
+
+        $passwords = $this->database->get_all_entries($userid);
+        $passwords = array_filter($passwords, function ($entry) {
+            return $entry['website'] == 'amazingsite';
+        });
+        $passwords = array_values($passwords);
+
+        $data = $this->database->get_password($passwords[0]['id']);
+        $this->assertEquals('amazingsite', $data['website']);
+        $this->assertEquals('testusername', $data['username']);
+        $this->assertEquals('testpassword', $data['password']);
+    }
 }
 ?>


### PR DESCRIPTION
## Motivation

The current implementation of how password details get to the frontend is very sketchy and not optimal.

## Changes

- change the get_password method to be useful -> decrypt password and ensure uniqueness
- add HTML data attribute for password ID
- use password ID to make AJAX request
- change AJAX handler to use get_password method

## Tests done

Checked if details get correctly loaded
Ran new test

## TODO

- [x] I've assigned this PR to myself
- [x] I've labeled this PR correctly
- [x] Add message in details bar
