### PR TITLE
Chore: composer in fpm container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,3 +4,4 @@ RUN apt-get update && apt-get upgrade -y
 RUN apt-get install libxml2-dev -y
 RUN pecl install xdebug-2.9.8 && docker-php-ext-enable xdebug
 RUN docker-php-ext-install mysqli pdo pdo_mysql dom xml && docker-php-ext-enable pdo_mysql
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,7 +4,7 @@ services:
     image: composer
     volumes:
       - ./:/app
-    command: composer install --ignore-platform-reqs
+    command: composer install
 
   web:
     image: nginx:latest
@@ -23,7 +23,7 @@ services:
       - .:/var/www/html
     env_file:
     - .env
-  
+
   db:
     image: mysql
     restart: always
@@ -45,4 +45,4 @@ services:
       - '8081:80'
     environment:
       PMA_HOST: db
-      MYSQL_ROOT_PASSWORD: root 
+      MYSQL_ROOT_PASSWORD: root


### PR DESCRIPTION
## Motivation
So when testing locally, you need to run `./vendor/bin/phpunit ....` to test. You have to copy the command every time.

## Changes

0efecd40470cdc0a5c9aa3cd1f2b30e416f06ffc
fe9df50d272ff606385d39b706428263e0c3476d

The new way is to run `composer test`

## Tests done

Run `composer test` in php-fpm container

## TODO

- [x] I've assigned this PR to myself
- [x] I've labeled this PR correctly