### PR TITLE
chore: update readme for releases and license

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,8 @@ Contributors names and contact info
 
 ## Version History
 
-* 0.1.0
-    * Initial Release
+You can see all of our versions at [releases](https://github.com/2223-Project-1/OmegaPass/releases).
 
 ## License
 
-This project is licensed under the [] License - see the LICENSE.md file for details
+This project is licensed under the GNU General Public License v2.0 License - see the LICENSE file for details.


### PR DESCRIPTION
## Motivation

Since we released our first version (1.0.0) the README the releases tab is for version history. Also the license was not named in it.

## Changes

- Link to the releases page
- Add license name

## TODO

- [x] I've assigned this PR to myself
- [x] I've labeled this PR correctly