### PR TITLE
fix: wrap form around input so browser doesn't autocomplete field

### DIFF
--- a/public/overview/index.php
+++ b/public/overview/index.php
@@ -149,7 +149,9 @@ switch ($_GET['mode']) {
         <div class="overview-passwords">
             <div class="overview-passwords-header">
                 <h3>Passwords</h3>
-                <input type="text" id="search" placeholder="Search..."/>
+                <form autocomplete="off">
+                    <input type="text" id="search" placeholder="Search..." autocomplete="off"/>
+                </form>
                 <button id="add-password">
                     <i class="bi bi-plus-lg"></i>
                 </button>


### PR DESCRIPTION
## Motivation

#76 

## Changes

Wrap form element and put input for search in it.

## Tests done

Search for something and it works. Auto fill is also disabled

## TODO

- [x] I've assigned this PR to myself
- [x] I've labeled this PR correctly
